### PR TITLE
Apply code suggestions from review

### DIFF
--- a/source/InjectHooksMain.cpp
+++ b/source/InjectHooksMain.cpp
@@ -348,6 +348,8 @@ void InjectHooksMain()
     CTaskComplexJump::InjectHooks();
     ModelIndices::InjectHooks();
     CWaterCannons::InjectHooks();
+    COctTree::InjectHooks();
+    COctTreeBase::InjectHooks();
 
     CAEVehicleAudioEntity::InjectHooks();
     CAESoundManager::InjectHooks();

--- a/source/game_sa/Core/COctTree.cpp
+++ b/source/game_sa/Core/COctTree.cpp
@@ -1,201 +1,38 @@
 #include "StdInc.h"
 
+#include "COctTree.h"
+
 bool& COctTree::ms_bFailed = *(bool*)0xBC12DC;
 uint32_t& COctTree::ms_level = *(uint32_t*)0xBC12E0;
 CPool<COctTree>& COctTree::ms_octTreePool = *(CPool<COctTree>*)0xBC12E4;
-COctTree** gpTmpOctTree = (COctTree**)0xBC12D8;
+COctTree*& gpTmpOctTree = *(COctTree**)0xBC12D8;
 
 //  0x5A6DB0
 COctTree::COctTree() {
-    level = 0;
-    redComponent = 0;
-    greenComponent = 0;
-    blueComponent = 0;
+    m_nLevel = 0;
+    m_nRedComponent = 0;
+    m_nGreenComponent = 0;
+    m_nBlueComponent = 0;
 
-    for (uint32_t i = ARRAY_SIZE(children) - 1; i; --i)
-        children[i] = -1;
+    for (uint32_t i = 0; i < ARRAY_SIZE(m_aChildrens); i++)
+        m_aChildrens[i] = -1;
 
-    lastStep = false;
+    m_bLastStep = false;
 }
 
 //  0x5A7490
 COctTree::~COctTree() {
     empty();
-    ms_octTreePool.Delete(this);
 }
 
-//  0x5A75B0
-bool COctTree::InsertTree(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue) {
-    const uint16_t poolIndex = ((colorRed << ms_level >> 5) & 4) + ((colorGreen << ms_level >> 6) & 2) + ((colorBlue << ms_level >> 7) & 1);
-    ms_level++;
-
-    redComponent += colorRed;
-    greenComponent += colorGreen;
-    blueComponent += colorBlue;
-    level++;
-
-    if (ms_level == ARRAY_SIZE(children) || lastStep) {
-        ms_level = 0;
-        lastStep = true;
-
-        RemoveChildren();
-
-        return level == 1;
-    }
-
-    COctTree* treeElement = nullptr;
-    if (children[poolIndex] >= 0) {
-        if (!ms_octTreePool.IsFreeSlotAtIndex(poolIndex))
-            treeElement = ms_octTreePool.GetAt(poolIndex);
-    } else {
-        treeElement = ms_octTreePool.New();
-
-        if (!treeElement) {
-            ms_bFailed = true;
-            return 0;
-        }
-
-        children[poolIndex] = ms_octTreePool.GetIndex(treeElement);
-    }
-
-#ifdef FIX_BUGS
-    if (!treeel)
-        return 0;
-#endif
-
-    bool bTreeInserted = treeElement->InsertTree(colorRed, colorGreen, colorBlue);
-
-    if (ms_bFailed && treeElement->level < 2) {
-        delete treeElement;
-        children[poolIndex] = -1;
-
-        return 0;
-    }
-
-    return bTreeInserted;
+//  0x5A7410
+void* COctTree::operator new(uint32_t size) {
+    return ms_octTreePool.New();
 }
 
-//  0x5A70F0
-void COctTree::FillPalette(uint8_t* colors) {
-    if (lastStep == 1) {
-        colors[ms_level + 0] = redComponent / level;
-        colors[ms_level + 1] = greenComponent / level;
-        colors[ms_level + 2] = blueComponent / level;
-        colors[ms_level + 3] = 128;
-
-        level = ms_level++;
-    } else {
-        for (uint32_t i = ARRAY_SIZE(children) - 1; i; --i) {
-            const int16_t poolIndex = children[i];
-
-            if (poolIndex < 0)
-                continue;
-
-            if (!ms_octTreePool.IsFreeSlotAtIndex(poolIndex))
-                ms_octTreePool.GetAt(poolIndex)->FillPalette(colors);
-        }
-    }
-}
-
-//  0x5A71E0
-uint32_t COctTree::FindNearestColour(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue) {
-    if (lastStep != 0)
-        return level;
-
-    COctTree* treeElement = this;
-    do {
-        uint32_t treeIndex = treeElement->children[(colorBlue >> 7) + ((colorGreen >> 6) & 2) + ((colorRed >> 5) & 4)];
-        if (!ms_octTreePool.IsFreeSlotAtIndex(treeIndex))
-            treeElement = ms_octTreePool.GetAt(treeIndex);
-
-        colorRed *= 2;
-        colorGreen *= 2;
-        colorBlue *= 2;
-    } while (!treeElement->lastStep);
-
-    return treeElement->level;
-}
-
-//  0x5A6DE0
-uint32_t COctTree::NoOfChildren() {
-    unsigned int numOfChildren = 0;
-    for (uint32_t i = ARRAY_SIZE(children) - 1; i; --i)
-        if (children[i] >= 0)
-            numOfChildren++;
-
-    return numOfChildren;
-}
-
-//  0x5A7040
-void COctTree::ReduceTree() {
-    if (lastStep == 1)
-        return;
-
-    ms_level++;
-
-    uint32_t currentLevel = 0;
-    uint32_t totalLevels = 0;
-    static uint32_t lastLevel;
-    for (uint32_t i = ARRAY_SIZE(children) - 1; i; --i) {
-        if (children[i] < 0)
-            continue;
-
-        currentLevel++;
-
-        if (!ms_octTreePool.IsFreeSlotAtIndex(children[i])) {
-            COctTree* tree = ms_octTreePool.GetAt(children[i]);
-
-            tree->ReduceTree();
-            totalLevels += tree->level;
-        }
-    }
-
-    if (currentLevel >= 2 && (totalLevels < lastLevel || !*gpTmpOctTree)) {
-        lastLevel = totalLevels;
-        *gpTmpOctTree = this;
-    }
-
-    ms_level--;
-}
-
-//  0x5A74F0
-void COctTree::RemoveChildren() {
-    for (uint32_t i = ARRAY_SIZE(children) - 1; i; --i) {
-        const int16_t poolIndex = children[i];
-
-        if (poolIndex < 0)
-            continue;
-
-        if (ms_octTreePool.IsFreeSlotAtIndex(poolIndex))
-            continue;
-
-        if (!ms_octTreePool.GetAt(poolIndex))
-            continue;
-
-        delete ms_octTreePool.GetAt(poolIndex);
-
-        children[i] = -1;
-    }
-}
-
-//  0x5A6FC0
-void COctTree::empty() {
-    level = 0;
-    redComponent = 0;
-    greenComponent = 0;
-    blueComponent = 0;
-
-    for (uint32_t i = ARRAY_SIZE(children) - 1; i; --i) {
-        const int16_t poolIndex = children[i];
-
-        if (poolIndex < 0)
-            continue;
-
-        if (!ms_octTreePool.IsFreeSlotAtIndex(poolIndex) && ms_octTreePool.GetAt(poolIndex))
-            delete ms_octTreePool.GetAt(poolIndex);
-
-        children[i] = -1;
-    }
+// 0x5A7420
+void COctTree::operator delete(void* data) {
+    ms_octTreePool.Delete(static_cast<COctTree*>(data));
 }
 
 //  0x5A7460
@@ -209,24 +46,208 @@ void COctTree::ShutdownPool() {
     ms_octTreePool.Flush();
 }
 
-//  0x5A7410
-void* COctTree::operator new(uint32_t size) {
-    return ms_octTreePool.New();
+//  0x5A75B0
+bool COctTree::InsertTree(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue) {
+    const uint16_t poolIndex = ((colorRed << ms_level >> 5) & 4) + ((colorGreen << ms_level >> 6) & 2) + ((colorBlue << ms_level >> 7) & 1);
+    ms_level++;
+
+    m_nRedComponent += colorRed;
+    m_nGreenComponent += colorGreen;
+    m_nBlueComponent += colorBlue;
+    m_nLevel++;
+
+    if (ms_level == ARRAY_SIZE(m_aChildrens) || m_bLastStep) {
+        ms_level = 0;
+        m_bLastStep = true;
+
+        RemoveChildren();
+
+        return m_nLevel == 1;
+    }
+
+    COctTree* treeElement = nullptr;
+    if (m_aChildrens[poolIndex] >= 0) {
+        if (!ms_octTreePool.IsFreeSlotAtIndex(poolIndex))
+            treeElement = ms_octTreePool.GetAt(poolIndex);
+    } else {
+        treeElement = ms_octTreePool.New();
+
+        if (!treeElement) {
+            ms_bFailed = true;
+            return false;
+        }
+
+        m_aChildrens[poolIndex] = ms_octTreePool.GetIndex(treeElement);
+    }
+
+#ifdef FIX_BUGS
+    if (!treeElement)
+        return 0;
+#endif
+
+    bool bTreeInserted = treeElement->InsertTree(colorRed, colorGreen, colorBlue);
+
+    if (ms_bFailed && treeElement->m_nLevel < 2) {
+        delete treeElement;
+        m_aChildrens[poolIndex] = -1;
+
+        return false;
+    }
+
+    return bTreeInserted;
+}
+
+//  0x5A70F0
+void COctTree::FillPalette(uint8_t* colors) {
+    if (m_bLastStep == 1) {
+        colors[ms_level + 0] = m_nRedComponent / m_nLevel;
+        colors[ms_level + 1] = m_nGreenComponent / m_nLevel;
+        colors[ms_level + 2] = m_nBlueComponent / m_nLevel;
+        colors[ms_level + 3] = 128;
+
+        m_nLevel = ms_level++;
+    } else {
+        for (uint32_t i = ARRAY_SIZE(m_aChildrens) - 1; i; --i) {
+            const int16_t poolIndex = m_aChildrens[i];
+
+            if (poolIndex < 0)
+                continue;
+
+            if (!ms_octTreePool.IsFreeSlotAtIndex(poolIndex))
+                ms_octTreePool.GetAt(poolIndex)->FillPalette(colors);
+        }
+    }
+}
+
+//  0x5A71E0
+uint32_t COctTree::FindNearestColour(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue) {
+    if (m_bLastStep != 0)
+        return m_nLevel;
+
+    COctTree* treeElement = this;
+    do {
+        uint32_t treeIndex = treeElement->m_aChildrens[(colorBlue >> 7) + ((colorGreen >> 6) & 2) + ((colorRed >> 5) & 4)];
+        if (!ms_octTreePool.IsFreeSlotAtIndex(treeIndex))
+            treeElement = ms_octTreePool.GetAt(treeIndex);
+
+        colorRed *= 2;
+        colorGreen *= 2;
+        colorBlue *= 2;
+    } while (!treeElement->m_bLastStep);
+
+    return treeElement->m_nLevel;
+}
+
+//  0x5A6DE0
+uint32_t COctTree::NoOfChildren() {
+    uint32_t numOfChildren = 0;
+    for (uint32_t i = 0; i < ARRAY_SIZE(m_aChildrens); i++)
+        if (m_aChildrens[i] >= 0)
+            numOfChildren++;
+
+    return numOfChildren;
+}
+
+//  0x5A7040
+void COctTree::ReduceTree() {
+    if (m_bLastStep == 1)
+        return;
+
+    ms_level++;
+
+    uint32_t currentLevel = 0;
+    uint32_t totalLevels = 0;
+    static uint32_t lastLevel;
+    for (uint32_t i = ARRAY_SIZE(m_aChildrens) - 1; i; --i) {
+        if (m_aChildrens[i] < 0)
+            continue;
+
+        currentLevel++;
+
+        if (!ms_octTreePool.IsFreeSlotAtIndex(m_aChildrens[i])) {
+            COctTree* tree = ms_octTreePool.GetAt(m_aChildrens[i]);
+
+            tree->ReduceTree();
+            totalLevels += tree->m_nLevel;
+        }
+    }
+
+    if (currentLevel >= 2 && (totalLevels < lastLevel || !gpTmpOctTree)) {
+        lastLevel = totalLevels;
+        gpTmpOctTree = this;
+    }
+
+    ms_level--;
+}
+
+//  0x5A74F0
+void COctTree::RemoveChildren() {
+    for (uint32_t i = ARRAY_SIZE(m_aChildrens) - 1; i; --i) {
+        int16_t& poolIndex = m_aChildrens[i];
+
+        if (poolIndex < 0)
+            continue;
+
+        if (ms_octTreePool.IsFreeSlotAtIndex(poolIndex))
+            continue;
+
+        COctTree* elem = ms_octTreePool.GetAt(poolIndex);
+        if (!elem)
+            continue;
+
+        delete elem;
+        poolIndex = -1;
+    }
+}
+
+//  0x5A6FC0
+void COctTree::empty() {
+    m_nLevel = 0;
+    m_nRedComponent = 0;
+    m_nGreenComponent = 0;
+    m_nBlueComponent = 0;
+
+    for (uint32_t i = ARRAY_SIZE(m_aChildrens) - 1; i; --i) {
+        int16_t& poolIndex = m_aChildrens[i];
+
+        if (poolIndex < 0)
+            continue;
+
+        if (!ms_octTreePool.IsFreeSlotAtIndex(poolIndex) && ms_octTreePool.GetAt(poolIndex))
+            delete ms_octTreePool.GetAt(poolIndex);
+
+        poolIndex = -1;
+    }
 }
 
 void COctTree::InjectHooks() {
-    //  Virtual class methods
-    ReversibleHooks::Install("COctTree", "InsertTree", 0x5A75B0, &COctTree::InsertTree);
-    ReversibleHooks::Install("COctTree", "FillPalette", 0x5A70F0, &COctTree::FillPalette);
-
-    //  Class methods
+    ReversibleHooks::Install("COctTree", "COctTree", 0x5A6DB0, &COctTree::Constructor);
+    ReversibleHooks::Install("COctTree", "~COctTree", 0x5A7490, &COctTree::Destructor);
+    ReversibleHooks::Install("COctTree", "InitPool", 0x5A7460, &COctTree::InitPool);
+    ReversibleHooks::Install("COctTree", "ShutdownPool", 0x5A6F70, &COctTree::ShutdownPool);
+    ReversibleHooks::Install("COctTree", "InsertTree", 0x5A75B0, &COctTree::InsertTree_Reversed);
+    ReversibleHooks::Install("COctTree", "FillPalette", 0x5A70F0, &COctTree::FillPalette_Reversed);
     ReversibleHooks::Install("COctTree", "FindNearestColour", 0x5A71E0, &COctTree::FindNearestColour);
     ReversibleHooks::Install("COctTree", "NoOfChildren", 0x5A6DE0, &COctTree::NoOfChildren);
     ReversibleHooks::Install("COctTree", "ReduceTree", 0x5A7040, &COctTree::ReduceTree);
     ReversibleHooks::Install("COctTree", "RemoveChildren", 0x5A74F0, &COctTree::RemoveChildren);
     ReversibleHooks::Install("COctTree", "empty", 0x5A6FC0, &COctTree::empty);
+}
 
-    //  Static class methods
-    ReversibleHooks::Install("COctTree", "InitPool", 0x5A7460, &COctTree::InitPool);
-    ReversibleHooks::Install("COctTree", "ShutdownPool", 0x5A6F70, &COctTree::ShutdownPool);
+COctTree* COctTree::Constructor() {
+    this->COctTree::COctTree();
+    return this;
+}
+
+COctTree* COctTree::Destructor() {
+    this->COctTree::~COctTree();
+    return this;
+}
+
+bool COctTree::InsertTree_Reversed(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue) {
+    return COctTree::InsertTree(colorRed, colorGreen, colorBlue);
+}
+
+void COctTree::FillPalette_Reversed(uint8_t* colors) {
+    COctTree::FillPalette(colors);
 }

--- a/source/game_sa/Core/COctTree.h
+++ b/source/game_sa/Core/COctTree.h
@@ -6,35 +6,34 @@
 */
 #pragma once
 
-#include "PluginBase.h"
 #include "CPool.h"
 
-class  COctTree {
+class COctTree {
 public:
-    uint32_t                level;
-    bool                    lastStep;       // no children
-private:
+    uint32_t                m_nLevel;
+    bool                    m_bLastStep;       // no children
     char                    _pad09;
-public:
-    short                   children[8];    // pool slot IDs,  -1 - empty
-private:
+    short m_aChildrens[8];    // pool slot IDs,  -1 - empty
     char                    _pad1A[2];
-public:
-    uint32_t                redComponent;
-    uint32_t                greenComponent;
-    uint32_t                blueComponent;
+    uint32_t                m_nRedComponent;
+    uint32_t                m_nGreenComponent;
+    uint32_t                m_nBlueComponent;
 
+public:
     static bool&            ms_bFailed;
     static uint32_t&        ms_level;
     static CPool<COctTree>& ms_octTreePool;
 
-    //vtable
-
-    virtual bool            InsertTree(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue);
-    virtual void            FillPalette(uint8_t* colors);
-
+public:
     COctTree();
     ~COctTree();
+
+    static void*            operator new(uint32_t size);
+    static void             operator delete(void* data);
+
+    //vtable
+    virtual bool            InsertTree(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue);
+    virtual void            FillPalette(uint8_t* colors);
 
     uint32_t                FindNearestColour(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue);
     uint32_t                NoOfChildren();
@@ -45,12 +44,17 @@ public:
     static void             InitPool(void* data, int32_t dataSize);
     static void             ShutdownPool();
 
-    //static void operator delete(void* data);  //  Not needed, since destructor already does what this operator does.
-    static void*            operator new(uint32_t size);
+private:
+    friend void InjectHooksMain();
+    static void InjectHooks();
 
-    static void             InjectHooks();
+    COctTree* Constructor();
+    COctTree* Destructor();
+
+    bool InsertTree_Reversed(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue);
+    void FillPalette_Reversed(uint8_t* colors);
 };
 
 VALIDATE_SIZE(COctTree, 0x28);
 
-extern COctTree **gpTmpOctTree;
+extern COctTree*& gpTmpOctTree;

--- a/source/game_sa/Core/COctTreeBase.h
+++ b/source/game_sa/Core/COctTreeBase.h
@@ -6,29 +6,37 @@
 */
 #pragma once
 
-#include "PluginBase.h"
 #include "COctTree.h"
 
-class  COctTreeBase : public COctTree {
+class COctTreeBase : public COctTree {
 public:
-    uint32_t        numBranches;
-    bool32          hasTransparentPixels;
+    uint32_t m_nNumBranches;
+    bool32   m_bHasTransparentPixels;
 
-    //vtable
-
-    virtual bool    InsertTree(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue) override;
-    virtual void    FillPalette(uint8_t* colors) override;
-
+public:
     COctTreeBase();
     ~COctTreeBase();
 
-    void            Init(int32_t numBranches);
-    bool            Insert(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue);
-    void            ReduceBranches(int32_t newBranchesCount);
+    //vtable
 
-    static void     InjectHooks();
+    bool InsertTree(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue) override;
+    void FillPalette(uint8_t* colors) override;
+
+    void Init(int32_t numBranches);
+    bool Insert(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue);
+    void ReduceBranches(int32_t newBranchesCount);
+
+private:
+    friend void InjectHooksMain();
+    static void InjectHooks();
+
+    COctTreeBase* Constructor();
+    COctTreeBase* Destructor();
+
+    bool InsertTree_Reversed(uint8_t colorRed, uint8_t colorGreen, uint8_t colorBlue);
+    void FillPalette_Reversed(uint8_t* colors);
 };
 
-extern COctTreeBase** gOctTreeBase;
+extern COctTreeBase& gOctTreeBase;
 
 VALIDATE_SIZE(COctTreeBase, 0x30);

--- a/source/game_sa/GxtChar.cpp
+++ b/source/game_sa/GxtChar.cpp
@@ -2,8 +2,6 @@
 
 #include "GxtChar.h"
 
-#define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
-
 // 0x718600
 void AsciiToGxtChar(const char* src, GxtChar* dst) {
     for (int i = 0; src[i]; ++i) {


### PR DESCRIPTION
We have crash at exit due ``COctTree::ms_octTreePool`` not initialized (and never will be). ``CClothesBuilder::InitPaletteOctTree`` and ``CClothesBuilder::ReducePaletteSize`` should intialize ``COctTree and ``COctTreeBase`` stuff but they unused.


- Fixed ``COctTree::operator delete``
- Fixed ``COctTreeBase`` initialization
- Class members renamed to be accomplish Hungarian notation
- Slightly changed the order of functions
- Virtual functions and ctor/dtor now hooked
- Fixed missing ``COctTree::InjectHooks()`` and ``COctTreeBase::InjectHooks()``;

Suggestions:
- [ ] fix crash 😃 
- [ ] This can be simplified in  ``COctTree::empty``
```C++
if (!ms_octTreePool.IsFreeSlotAtIndex(poolIndex) && ms_octTreePool.GetAt(poolIndex))
    delete ms_octTreePool.GetAt(poolIndex);
```
```C++
delete ms_octTreePool.GetAt(poolIndex);
```